### PR TITLE
refactor(spinner): introduce reusable spinner types and improve API

### DIFF
--- a/lua/streamline/components.lua
+++ b/lua/streamline/components.lua
@@ -8,5 +8,6 @@ M.filetype = require("streamline.components.filetype").filetype
 M.indent = require("streamline.components.indent").indent
 M.macro = require("streamline.components.macro").macro
 M.codecompanion = require("streamline.components.codecompanion").codecompanion
+M.spinnertest = require("streamline.components.spinnertest").spinnertest
 
 return M

--- a/lua/streamline/components/codecompanion.lua
+++ b/lua/streamline/components/codecompanion.lua
@@ -8,64 +8,6 @@ local state = {
   spinner_id = "CodeCompanion",
 }
 
-local spinnerFrames = {}
-local function setupSpinnerFrames()
-  -- Define highlight group constants for better readability
-  local ON = "%#StreamlineCodecompanionSpinnerOn#"
-  local OFF = "%#StreamlineCodecompanionSpinnerOff#"
-
-  -- Define the unique frame patterns
-  --   
-  --   
-  --   
-  local patterns = {
-    ON .. " " .. OFF .. "  ",
-    OFF .. " " .. ON .. " " .. OFF .. " ",
-    OFF .. "  " .. ON .. " ",
-  }
-
-  spinnerFrames = {}
-  for _, pattern in ipairs(patterns) do
-    for _ = 1, 4 do
-      table.insert(spinnerFrames, pattern)
-    end
-  end
-end
-
-local function setupHooks()
-  local group = vim.api.nvim_create_augroup("CodeCompanionHooks", {})
-
-  -- Define event mappings
-  local spinner_start_events = {
-    ["CodeCompanionRequestStarted"] = true,
-    ["CodeCompanionRequestStreaming"] = true,
-    ["CodeCompanionRequestStartedInlineStarted"] = true,
-  }
-
-  local spinner_stop_events = {
-    ["CodeCompanionRequestFinished"] = true,
-    ["CodeCompanionInlineFinished"] = true,
-  }
-
-  vim.api.nvim_create_autocmd({ "User" }, {
-    pattern = "CodeCompanionRequest*",
-    group = group,
-    callback = function(request)
-      local name = request.data and request.data.adapter.formatted_name or "unknown"
-      local spinner_id = state.spinner_id
-
-      state.state = request.match
-      state.name = name
-
-      if spinner_start_events[request.match] then
-        require("streamline.spinner").start(spinner_id, spinnerFrames)
-      elseif spinner_stop_events[request.match] then
-        require("streamline.spinner").stop(spinner_id)
-      end
-    end,
-  })
-end
-
 function M.codecompanion()
   local spinner_id = state.spinner_id
   local name = state.name or "CodeCompanion"
@@ -104,8 +46,37 @@ function M.codecompanion()
 end
 
 function M.setup()
-  setupSpinnerFrames()
-  setupHooks()
+  local group = vim.api.nvim_create_augroup("CodeCompanionHooks", {})
+
+  -- Define event mappings
+  local spinner_start_events = {
+    ["CodeCompanionRequestStarted"] = true,
+    ["CodeCompanionRequestStreaming"] = true,
+    ["CodeCompanionRequestStartedInlineStarted"] = true,
+  }
+
+  local spinner_stop_events = {
+    ["CodeCompanionRequestFinished"] = true,
+    ["CodeCompanionInlineFinished"] = true,
+  }
+
+  vim.api.nvim_create_autocmd({ "User" }, {
+    pattern = "CodeCompanionRequest*",
+    group = group,
+    callback = function(request)
+      local name = request.data and request.data.adapter.formatted_name or "unknown"
+      local spinner_id = state.spinner_id
+
+      state.state = request.match
+      state.name = name
+
+      if spinner_start_events[request.match] then
+        require("streamline.spinner").start(spinner_id, "dotProgressSpinner")
+      elseif spinner_stop_events[request.match] then
+        require("streamline.spinner").stop(spinner_id)
+      end
+    end,
+  })
 end
 
 M.setup()

--- a/lua/streamline/components/macro.lua
+++ b/lua/streamline/components/macro.lua
@@ -4,13 +4,12 @@ local utils = require("streamline.utils")
 function M.setup()
   -- Set up autocommand for macro recording
   local group = vim.api.nvim_create_augroup("MacroRecording", {})
-  local recording_icon_frames = { "󰑋", "󰑋", "󰑋", "󰑋", "󰑋", " ", " ", " ", " ", " " }
 
   vim.api.nvim_create_autocmd({ "RecordingEnter" }, {
     group = group,
     pattern = "*",
     callback = function()
-      require("streamline.spinner").start("macro", recording_icon_frames, "StreamlineRecordingIcon")
+      require("streamline.spinner").start("macro", "recordingButton")
     end,
   })
 

--- a/lua/streamline/components/spinnertest.lua
+++ b/lua/streamline/components/spinnertest.lua
@@ -1,0 +1,19 @@
+local M = {}
+local utils = require("streamline.utils")
+
+function M.spinnertest()
+  local spinner = require("streamline.spinner").spinner("spinnertest")
+  local spinnerRecord = require("streamline.spinner").spinner("spinnertestRecord")
+  local spinnerDot = require("streamline.spinner").spinner("spinnertestDot")
+  return spinner .. spinnerRecord .. spinnerDot .. utils.styled("StreamlineSpinnerTest", "Spinner Test")
+end
+
+function M.setup()
+  require("streamline.spinner").start("spinnertest")
+  require("streamline.spinner").start("spinnertestRecord", "recordingButton")
+  require("streamline.spinner").start("spinnertestDot", "dotProgressSpinner")
+end
+
+M.setup()
+
+return M

--- a/lua/streamline/spinner.lua
+++ b/lua/streamline/spinner.lua
@@ -3,19 +3,68 @@ local utils = require("streamline.utils")
 
 local spinner_frames = { " ◜", " ◠", " ◝", " ◞", " ◡", " ◟" }
 
+local function getDotProgressSpinner()
+  -- Define highlight group constants for better readability
+  local ON = "%#StreamlineCodecompanionSpinnerOn#"
+  local OFF = "%#StreamlineCodecompanionSpinnerOff#"
+
+  -- Define the unique frame patterns
+  --   
+  --   
+  --   
+  local patterns = {
+    ON .. " " .. OFF .. "  ",
+    OFF .. " " .. ON .. " " .. OFF .. " ",
+    OFF .. "  " .. ON .. " ",
+  }
+
+  local frames = {}
+  for _, pattern in ipairs(patterns) do
+    for _ = 1, 4 do
+      table.insert(frames, pattern)
+    end
+  end
+
+  return frames
+end
+
+local getRecordingSpinner = function()
+  local ON = "%#StreamlineRecordingIcon#"
+
+  local patterns = {
+    ON .. "󰑋",
+    " ",
+  }
+
+  local frames = {}
+  for _, pattern in ipairs(patterns) do
+    for _ = 1, 5 do
+      table.insert(frames, pattern)
+    end
+  end
+
+  return frames
+end
+
+local spinnerTypes = {
+  default = spinner_frames,
+  recordingButton = getRecordingSpinner(),
+  dotProgressSpinner = getDotProgressSpinner(),
+}
+
 -- Store all spinners in a table indexed by ID
 local spinners = {}
 -- Global timer for all spinners
 local global_timer = nil
 
 -- Create a new spinner instance
-function M.create(id, frames, spinner_hl)
+function M.create(id, type, spinner_hl)
   -- Create a new spinner if it doesn't already exist
   if not spinners[id] then
     spinners[id] = {
       active = false,
+      type = type or "default",
       frame = 1,
-      frames = frames,
       spinner_hl = spinner_hl or "StreamlineSpinner",
     }
   end
@@ -23,10 +72,10 @@ function M.create(id, frames, spinner_hl)
 end
 
 -- Start a spinner by ID
-function M.start(id, frames, spinner_hl)
+function M.start(id, type, spinner_hl)
   -- Create spinner if it doesn't exist
   if not spinners[id] then
-    M.create(id, frames, spinner_hl)
+    M.create(id, type, spinner_hl)
   end
 
   -- Update spinner state
@@ -49,9 +98,9 @@ function M.start(id, frames, spinner_hl)
           -- Update all active spinners
           for _, spinner in pairs(spinners) do
             if spinner.active then
-              local frms = spinner.frames or spinner_frames
+              local frames = spinnerTypes[spinner.type] or spinner_frames
               any_active = true
-              spinner.frame = (spinner.frame % #frms) + 1
+              spinner.frame = (spinner.frame % #frames) + 1
             end
           end
 
@@ -106,7 +155,7 @@ function M.spinner(id)
       return ""
     end
 
-    local frames = spinner.frames or spinner_frames
+    local frames = spinnerTypes[spinner.type] or spinner_frames
     local frame = frames[spinner.frame]
     return utils.styled(spinner.spinner_hl, "" .. frame)
   end


### PR DESCRIPTION
- Refactor spinner implementation to use predefined spinner types
- Move spinner frames from component files into central spinner.lua
- Add default, recordingButton, and dotProgressSpinner spinner types
- Update codecompanion and macro components to use the new API
- Add spinnertest component for demonstration purposes